### PR TITLE
Explicitly convert NodeList to Array.

### DIFF
--- a/dist/lib/dom_helpers.js
+++ b/dist/lib/dom_helpers.js
@@ -10,8 +10,6 @@ Object.defineProperty(exports, '__esModule', {
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { 'default': obj }; }
 
-function _toConsumableArray(arr) { if (Array.isArray(arr)) { for (var i = 0, arr2 = Array(arr.length); i < arr.length; i++) arr2[i] = arr[i]; return arr2; } else { return Array.from(arr); } }
-
 var _reactDom = require('react-dom');
 
 var _reactDom2 = _interopRequireDefault(_reactDom);
@@ -37,20 +35,18 @@ function bindFocusables(instance, activateOnFocus) {
     if (node) {
       var focusables = node.querySelectorAll(focusableSelector);
       if (focusables.length) {
-        var onFocus = function onFocus(element) {
-          var onFocusPrev = element.onfocus;
-          return function (event) {
-            activateOnFocus(instance);
-            if (onFocusPrev) onFocusPrev.call(element, event);
+        (function () {
+          var onFocus = function onFocus(element) {
+            var onFocusPrev = element.onfocus;
+            return function (event) {
+              activateOnFocus(instance);
+              if (onFocusPrev) onFocusPrev.call(element, event);
+            };
           };
-        };
-
-        var _arr = [].concat(_toConsumableArray(focusables));
-
-        for (var _i = 0; _i < _arr.length; _i++) {
-          var element = _arr[_i];
-          element.onfocus = onFocus(element);
-        }
+          Array.prototype.slice.call(focusables).forEach(function (element) {
+            return element.onfocus = onFocus(element);
+          });
+        })();
       }
     }
   }

--- a/dist/lib/uuid.js
+++ b/dist/lib/uuid.js
@@ -1,8 +1,3 @@
-/**
- * http://jsperf.com/uuid-generator-opt/4 
- *
- */
-
 // Counter being incremented. JS is single-threaded, so it'll Just Work™.
 "use strict";
 

--- a/src/lib/dom_helpers.js
+++ b/src/lib/dom_helpers.js
@@ -32,9 +32,9 @@ function bindFocusables( instance, activateOnFocus ) {
             if ( onFocusPrev ) onFocusPrev.call( element, event );
           };
         };
-        for ( let element of [ ...focusables ] ) {
-          element.onfocus = onFocus( element );
-        }
+        Array.prototype.slice.call( focusables ).forEach( element => (
+          element.onfocus = onFocus( element )
+        ) );
       }
     }
   }


### PR DESCRIPTION
This avoids babel generating _toConsumableArray and using Array.from,
which then requires polyfilling.
