### PR TITLE
Fix Symbol type checking

### DIFF
--- a/src/lib/keys.js
+++ b/src/lib/keys.js
@@ -50,7 +50,7 @@ export const modifiers = {
 };
 
 export function allKeys( arg ) {
-  return arg ? typeof arg === 'symbol' : Symbol( 'allKeys' );
+  return arg ? (arg.constructor === Symbol || typeof arg === 'symbol') : Symbol( 'allKeys' );
 }
 
 export default Keys;


### PR DESCRIPTION
This fix allow to use react-keydown with symbol polyfill 