### PR TITLE
Bind click event in capture mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## 1.7.8
+
+- [Fix] Reverted changes made in 1.7.5 to 1.7.7 & added click check in capture mode
+  See [#55 (comment)](https://github.com/glortho/react-keydown/issues/55#issuecomment-318456804)
+
 ## 1.7.5-7
 
 - [Fix] Do not reshuffle activation order of bound instances on click if the

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-keydown",
-  "version": "1.7.7",
+  "version": "1.7.8",
   "description": "Lightweight keydown wrapper for React components",
   "main": "dist/index.js",
   "jsnext:main": "es/index.js",

--- a/src/event_handlers.js
+++ b/src/event_handlers.js
@@ -20,8 +20,6 @@ import store      from './store';
  * @param {object} event.target The DOM node from the click event
  */
 export function _onClick( { target } ) {
-  // only reshuffle order if the click target is no longer in the
-  // DOM. See https://github.com/glortho/react-keydown/issues/55
   store.activate(
     [ ...store.getInstances() ]
       .reduce( domHelpers.findContainerNodes( target ), [] )

--- a/src/event_handlers.js
+++ b/src/event_handlers.js
@@ -22,14 +22,12 @@ import store      from './store';
 export function _onClick( { target } ) {
   // only reshuffle order if the click target is no longer in the
   // DOM. See https://github.com/glortho/react-keydown/issues/55
-  if ( domHelpers.isAttached( target ) ) {
-    store.activate(
-      [ ...store.getInstances() ]
-        .reduce( domHelpers.findContainerNodes( target ), [] )
-        .sort( domHelpers.sortByDOMPosition )
-        .map( item => item.instance )
-    );
-  }
+  store.activate(
+    [ ...store.getInstances() ]
+      .reduce( domHelpers.findContainerNodes( target ), [] )
+      .sort( domHelpers.sortByDOMPosition )
+      .map( item => item.instance )
+  );
 }
 
 /**

--- a/src/lib/dom_helpers.js
+++ b/src/lib/dom_helpers.js
@@ -62,14 +62,6 @@ function findContainerNodes( target ) {
   };
 }
 
-function isAttached( node ) {
-  return (
-    node &&
-    node !== document &&
-    node.parentNode
-  );
-}
-
 /**
  * sortByDOMPosition: Called by our click handler to sort a list of instances
  * according to least -> most nested. This is so that if multiple keybound
@@ -81,4 +73,4 @@ function sortByDOMPosition( a, b ) {
   return a.node.compareDocumentPosition( b.node ) === 10 ? 1 : -1;
 }
 
-export default { bindFocusables, findContainerNodes, isAttached, sortByDOMPosition };
+export default { bindFocusables, findContainerNodes, sortByDOMPosition };

--- a/src/lib/listeners.js
+++ b/src/lib/listeners.js
@@ -41,7 +41,7 @@ const Listeners = {
    */
   bindClicks( callback ) {
     if ( !_clicksBound ) {
-      document.addEventListener( 'click', callback );
+      document.addEventListener( 'click', callback, true );
       _clicksBound = true;
     }
   },
@@ -53,7 +53,7 @@ const Listeners = {
    */
   unbindClicks( callback ) {
     if ( _clicksBound ) {
-      document.removeEventListener( 'click', callback );
+      document.removeEventListener( 'click', callback, true );
       _clicksBound = false;
     }
   }


### PR DESCRIPTION
## Description

With this PR, I'm binding `click` event in capture mode. Giving our code a chance to execute before user's code is executed, which could potentially result in its removal from DOM, or even a `stopPropagation` could make us from detecting user's click and hence messing up our focused element order.

## Issue
https://github.com/glortho/react-keydown/issues/55#issuecomment-318456804