### PR TITLE
All keys

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,10 @@
+{
+  "ecmaFeatures": {
+    "jsx": true,
+    "modules": true
+  },
+  "env": {
+    "browser": true,
+    "es6": true
+  }
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## 1.8.0
+
+- [Fix] Added support for ALL_KEYS in `keydownScoped` decorator.
+  See [#56](https://github.com/glortho/react-keydown/issues/56)
+
 ## 1.7.8
 
 - [Fix] Reverted changes made in 1.7.5 to 1.7.7 & added click check in capture mode

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![dependencies](https://david-dm.org/glortho/react-keydown.svg)](https://david-dm.org/glortho/react-keydown.svg)
 
 Use react-keydown as a higher-order component or decorator to pass keydown
-events to the wrapped component, or call methods directly via designated keys. Good 
+events to the wrapped component, or call methods directly via designated keys. Good
 for implementing keyboard navigation or other shortcuts.
 
 Key advantages:
@@ -126,6 +126,19 @@ This is a convenience method, but also lets you specify a larger view context wh
 
 This can also be a good way to set up app-wide shortcuts. Wrap your root component with `@keydown` and then use  `@keydownScoped` or manually inspect the `keydown.event` props in the child components where those bindings are relevant.
 
+### Handling all keys using `keydownScoped` decorator
+
+In some cases you might want to handle keys on your own. For that, you can specify the following
+
+```
+import { keydownScoped, ALL_KEYS } from 'react-keydown'
+
+@keydownScoped(ALL_KEYS)
+beginEdit() {
+  // Start editing
+}
+```
+
 ### Caveat: Input, textarea, and select elements
 
 By default, bindings will not work when these fields have focus, in order not to interfere with user input and shortcuts related to these controls. You can override this in two ways:
@@ -141,7 +154,7 @@ class MyClass extends React.Component {
   myMethod( event ) {
     console.log( event ); // should log only on 'a' keystroke, whether input is focused or not
   }
-  
+
   render() {
     return <input onKeyDown={ this.myMethod } />;
   }
@@ -166,7 +179,7 @@ Note that this is very much a work in progress!
 ```
 $ npm test
 ```
-  
+
 
 ## Notes, disclaimers, and tips
 

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "scripts": {
     "build": "BABEL_ENV=production babel -d ./dist ./src",
     "build:es": "babel -d ./es ./src",
+    "build:es:watch": "babel --watch -d ./es ./src",
     "prepublish": "npm run build & npm run build:es",
     "test": "BABEL_ENV=testing babel-node node_modules/.bin/tape tests/*.js | node_modules/.bin/tap-difflet"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-keydown",
-  "version": "1.7.8",
+  "version": "1.8.0",
   "description": "Lightweight keydown wrapper for React components",
   "main": "dist/index.js",
   "jsnext:main": "es/index.js",

--- a/src/decorators/index.js
+++ b/src/decorators/index.js
@@ -8,6 +8,15 @@ import classWrapper        from './class_decorator';
 import methodWrapper       from './method_decorator';
 import methodWrapperScoped from './method_decorator_scoped';
 
+/**
+ * noopDecorator
+ *
+ * @access private
+ * @return {undefined} Returns `undefined` so that the original undecorated instance/method is used
+ */
+function noopDecorator () {
+  return undefined
+}
 
 /**
  * _decorator
@@ -18,7 +27,6 @@ import methodWrapperScoped from './method_decorator_scoped';
  * @return {Function} The decorated class or method
  */
 function _decorator( methodFn, ...args ) {
-
   // check the first argument to see if it's a user-supplied keycode or array
   // of keycodes, or if it's the wrapped class or method
   const testArg = args[0];
@@ -39,13 +47,15 @@ function _decorator( methodFn, ...args ) {
         classWrapper( target, keys );
     };
   } else {
+    const WrappedComponent = args[0];
     const methodName = args[1];
 
     // method decorators without keycode (which) arguments are not allowed.
-    if ( !methodName ) {
+    if ( WrappedComponent && !methodName ) {
       return classWrapper( ...args );
     } else {
       console.warn( `${methodName}: Method decorators must have keycode arguments, so the decorator for this method will not do anything` );
+      return noopDecorator
     }
   }
 }

--- a/src/decorators/index.js
+++ b/src/decorators/index.js
@@ -2,9 +2,12 @@
  * @module decorators
  *
  */
+import { ALL_KEYS } from '../lib/keys';
+
 import classWrapper        from './class_decorator';
 import methodWrapper       from './method_decorator';
 import methodWrapperScoped from './method_decorator_scoped';
+
 
 /**
  * _decorator
@@ -24,7 +27,7 @@ function _decorator( methodFn, ...args ) {
   // if the test argument is not an object or function, it is user-supplied
   // keycodes. else there are no arguments and it's just the wrapped class
   // (method decorators must have keycode arguments).
-  if ( isArray || ~[ 'string', 'number' ].indexOf( typeof testArg ) ) {
+  if ( isArray || ~[ 'string', 'number' ].indexOf( typeof testArg ) || ALL_KEYS === testArg) {
     const keys = isArray ? testArg : args;
 
     // return the decorator function, which on the next call will look for

--- a/src/decorators/method_decorator_scoped.js
+++ b/src/decorators/method_decorator_scoped.js
@@ -2,27 +2,9 @@
  * @module methodWrapperScoped
  *
  */
+import { ALL_KEYS } from '../lib/keys';
 import matchKeys from '../lib/match_keys';
 import parseKeys from '../lib/parse_keys';
-
-/**
- * _shouldTrigger
- *
- * @access private
- * @param {object} thisProps Exsting props from the wrapped component
- * @param {object} thisProps.keydown The namespaced state from the higher-order
- * component (class_decorator)
- * @param {object} nextProps The incoming props from the wrapped component
- * @param {object} nextProps.keydown The namescaped state from the higher-order
- * component (class_decorator)
- * @param {array} keys The keys bound to the decorated method
- * @return {boolean} Whether all tests have passed
- */
-function _shouldTrigger( { keydown: keydownThis }, keydownNext ) {
-  return keydownNext &&
-         keydownNext.event && 
-         !keydownThis.event;
-}
 
 /**
  * methodWrapperScoped
@@ -42,17 +24,40 @@ function methodWrapperScoped( { target, descriptor, keys } ) {
   } else {
     const keySets = parseKeys( keys );
 
+    /**
+     * _shouldTrigger
+     *
+     * @access private
+     * @param {object} thisProps Exsting props from the wrapped component
+     * @param {object} thisProps.keydown The namespaced state from the higher-order
+     * component (class_decorator)
+     * @param {object} nextProps The incoming props from the wrapped component
+     * @param {object} nextProps.keydown The namescaped state from the higher-order
+     * component (class_decorator)
+     * @param {array} keys The keys bound to the decorated method
+     * @return {boolean} Whether all tests have passed
+     */
+    function _shouldTrigger (keydownThis, keydownNext) {
+      if (!(keydownNext && keydownNext.event && !keydownThis.event)) return false;
+
+      return (
+        ( ALL_KEYS === keys[0] ) ||
+        ( keySets.some( keySet => matchKeys( { keySet, event: keydownNext.event } ) ) )
+      )
+    }
+
     // wrap the component's lifecycle method to intercept key codes coming down
     // from the wrapped/scoped component up the view hierarchy. if new keydown
     // event has arrived and the key codes match what was specified in the
     // decorator, call the wrapped method.
     target.componentWillReceiveProps = function( nextProps, ...args ) {
-      const { keydown } = nextProps;
-      if ( _shouldTrigger( this.props, keydown ) ) {
-        if ( keySets.some( keySet => matchKeys( { keySet, event: keydown.event } ) ) ) {
-          return fn.call( this, keydown.event );
-        }
+      const { keydown: keydownNext } = nextProps;
+      const { keydown: keydownThis } = this.props;
+
+      if ( _shouldTrigger( keydownThis, keydownNext ) ) {
+        return fn.call( this, keydownNext.event );
       }
+
       if ( componentWillReceiveProps ) return componentWillReceiveProps.call( this, nextProps, ...args );
     };
   }

--- a/src/decorators/method_decorator_scoped.js
+++ b/src/decorators/method_decorator_scoped.js
@@ -2,7 +2,6 @@
  * @module methodWrapperScoped
  *
  */
-import { ALL_KEYS } from '../lib/keys';
 import matchKeys from '../lib/match_keys';
 import parseKeys from '../lib/parse_keys';
 

--- a/src/decorators/method_decorator_scoped.js
+++ b/src/decorators/method_decorator_scoped.js
@@ -39,10 +39,7 @@ function methodWrapperScoped( { target, descriptor, keys } ) {
     function _shouldTrigger (keydownThis, keydownNext) {
       if (!(keydownNext && keydownNext.event && !keydownThis.event)) return false;
 
-      return (
-        ( ALL_KEYS === keys[0] ) ||
-        ( keySets.some( keySet => matchKeys( { keySet, event: keydownNext.event } ) ) )
-      )
+      return ( keySets.some( keySet => matchKeys( { keySet, event: keydownNext.event } ) ) )
     }
 
     // wrap the component's lifecycle method to intercept key codes coming down

--- a/src/index.js
+++ b/src/index.js
@@ -8,4 +8,4 @@ export { default, keydownScoped } from './decorators';
 export { setBinding } from './store';
 
 // Keys - use this to find key codes for strings. for example: Keys.j, Keys.enter
-export { default as Keys } from './lib/keys';
+export { default as Keys, ALL_KEYS } from './lib/keys';

--- a/src/lib/keys.js
+++ b/src/lib/keys.js
@@ -53,4 +53,6 @@ export function allKeys( arg ) {
   return arg ? (arg.constructor === Symbol || typeof arg === 'symbol') : Symbol( 'allKeys' );
 }
 
+export const ALL_KEYS = Symbol('ALL_KEYS')
+
 export default Keys;

--- a/src/lib/keys.js
+++ b/src/lib/keys.js
@@ -49,10 +49,6 @@ export const modifiers = {
   alt:     'alt'
 };
 
-export function allKeys( arg ) {
-  return arg ? (arg.constructor === Symbol || typeof arg === 'symbol') : Symbol( 'allKeys' );
-}
-
 export const ALL_KEYS = Symbol('ALL_KEYS')
 
 export default Keys;

--- a/src/lib/match_keys.js
+++ b/src/lib/match_keys.js
@@ -1,16 +1,19 @@
-import { modifiers as modifierKeys } from './keys';
+import { modifiers as modifierKeys, ALL_KEYS } from './keys';
 
 const modKeys = Object.keys( modifierKeys );
 
-function matchKeys( { keySet: { key, modifiers = [] }, event } ) {
+function matchKeys( { keySet, event } ) {
+  const { key, modifiers = [] } = keySet;
+
   let keysMatch = false;
   if ( key === event.which ) {
     const evtModKeys = modKeys.filter( modKey => event[ `${modKey}Key` ] ).sort();
     keysMatch = (
-      modifiers.length === evtModKeys.length && 
+      modifiers.length === evtModKeys.length &&
       modifiers.every( ( modKey, index ) => evtModKeys[ index ] === modKey )
     );
   }
+
   return keysMatch;
 }
 

--- a/src/lib/match_keys.js
+++ b/src/lib/match_keys.js
@@ -3,6 +3,10 @@ import { modifiers as modifierKeys, ALL_KEYS } from './keys';
 const modKeys = Object.keys( modifierKeys );
 
 function matchKeys( { keySet, event } ) {
+  if (ALL_KEYS === keySet) {
+    return true
+  }
+
   const { key, modifiers = [] } = keySet;
 
   let keysMatch = false;

--- a/src/lib/parse_keys.js
+++ b/src/lib/parse_keys.js
@@ -1,14 +1,16 @@
-import Keys, { modifiers } from './keys';
+import Keys, { modifiers, ALL_KEYS } from './keys';
 
 function parseKeys( keysArray ) {
+  if (ALL_KEYS === keysArray[0]) return
+
   return keysArray.map( key => {
     let keySet = { key };
     if ( typeof key === 'string' ) {
       const keyString = key.toLowerCase().trim();
       const matches = keyString.split( /\s?\+\s?/ );
-      keySet = matches.length === 1 ? 
+      keySet = matches.length === 1 ?
         { key: Keys[ keyString ] } :
-        { 
+        {
           key: Keys[ matches.pop() ],
           modifiers: matches.map( modKey => modifiers[modKey] ).sort()
         };

--- a/src/lib/parse_keys.js
+++ b/src/lib/parse_keys.js
@@ -1,6 +1,10 @@
 import Keys, { modifiers, ALL_KEYS } from './keys';
 
 function parseKeys( keysArray ) {
+  if (!keysArray || ALL_KEYS === keysArray[0]) {
+    return ALL_KEYS
+  }
+
   return keysArray.map( key => {
     let keySet = { key };
     if ( typeof key === 'string' ) {

--- a/src/lib/parse_keys.js
+++ b/src/lib/parse_keys.js
@@ -1,8 +1,6 @@
 import Keys, { modifiers, ALL_KEYS } from './keys';
 
 function parseKeys( keysArray ) {
-  if (ALL_KEYS === keysArray[0]) return
-
   return keysArray.map( key => {
     let keySet = { key };
     if ( typeof key === 'string' ) {

--- a/src/store.js
+++ b/src/store.js
@@ -2,14 +2,14 @@
  * @module store
  *
  */
-import { allKeys } from './lib/keys';
+import { ALL_KEYS }   from './lib/keys';
 import matchKeys   from './lib/match_keys';
 import parseKeys   from './lib/parse_keys';
 import uuid        from './lib/uuid';
 
 /**
  * private
- * 
+ *
  */
 
 // dict for class prototypes => bindings
@@ -48,7 +48,7 @@ const Store = {
       _instances.add( null );
     } else {
       _instances.delete( null );
-      
+
       // deleting and then adding the instance(s) has the effect of sorting the set
       // according to instance activation (ascending)
       instancesArray.forEach( instance => {
@@ -78,7 +78,7 @@ const Store = {
       for ( const instance of [ ..._instances ].reverse() ) {
         const bindings = this.getBinding( instance.constructor.prototype );
         for ( const [ keySets, fn ] of bindings ) {
-          if ( allKeys( keySets ) || keySets.some( keyMatchesEvent ) ) {
+          if ( ALL_KEYS === keySets || keySets.some( keyMatchesEvent ) ) {
             // return when matching keybinding is found - i.e. only one
             // keybound component can respond to a given key code. to get around this,
             // scope a common ancestor component class with @keydown and use
@@ -133,7 +133,10 @@ const Store = {
    * @param {object} args.target The decorated class
    */
   setBinding( { keys, fn, target } ) {
-    const keySets = keys ? parseKeys( keys ) : allKeys() ;
+    const keySets = keys ? (
+      ALL_KEYS === keys[0] ? ALL_KEYS : parseKeys( keys )
+    ) : ALL_KEYS;
+
     const { __reactKeydownUUID } = target;
     if ( !__reactKeydownUUID ) {
       target.__reactKeydownUUID = uuid();

--- a/src/store.js
+++ b/src/store.js
@@ -2,7 +2,6 @@
  * @module store
  *
  */
-import { ALL_KEYS }   from './lib/keys';
 import matchKeys   from './lib/match_keys';
 import parseKeys   from './lib/parse_keys';
 import uuid        from './lib/uuid';
@@ -78,7 +77,7 @@ const Store = {
       for ( const instance of [ ..._instances ].reverse() ) {
         const bindings = this.getBinding( instance.constructor.prototype );
         for ( const [ keySets, fn ] of bindings ) {
-          if ( ALL_KEYS === keySets || keySets.some( keyMatchesEvent ) ) {
+          if ( keySets.some( keyMatchesEvent ) ) {
             // return when matching keybinding is found - i.e. only one
             // keybound component can respond to a given key code. to get around this,
             // scope a common ancestor component class with @keydown and use
@@ -133,9 +132,7 @@ const Store = {
    * @param {object} args.target The decorated class
    */
   setBinding( { keys, fn, target } ) {
-    const keySets = keys ? (
-      ALL_KEYS === keys[0] ? ALL_KEYS : parseKeys( keys )
-    ) : ALL_KEYS;
+    const keySets = parseKeys( keys );
 
     const { __reactKeydownUUID } = target;
     if ( !__reactKeydownUUID ) {

--- a/tests/store-test.js
+++ b/tests/store-test.js
@@ -1,7 +1,7 @@
 import test from 'tape';
 
 import eventFixture from './fixtures/event';
-import Keys, { allKeys } from '../src/lib/keys';
+import Keys, { ALL_KEYS } from '../src/lib/keys';
 import Store, { _resetStore } from '../src/store';
 
 const bindingFixture = () => ({ keys: [], fn: () => {}, target: {} });
@@ -77,13 +77,13 @@ test( 'Store - setBinding', t => {
   t.equal( val, fixture.fn, msg );
 
 
-  msg = 'binding map key is allKeys when no keys specified';
+  msg = 'binding map key is ALL_KEYS when no keys specified';
   {
     _resetStore();
     let fixture = bindingFixture();
     Store.setBinding( { ...fixture, keys: null } );
     const [ key ] = [ ...Store.getBinding( fixture.target ) ][0];
-    t.ok( allKeys( key ), msg );
+    t.ok( ALL_KEYS === key, msg );
   }
 
   t.end();


### PR DESCRIPTION
### Description
With this change, we can do the following.

```
import { keydownScoped, ALL_KEYS } from 'react-keydown'

@keydownScoped(ALL_KEYS)
beginEdit() {
  // Start editing
}
```

Next, I'd also like to suggest support for `ALL_PRINTABLE_KEYS`, this would be very useful if we want to track user's input for only printable characters and skip all other keys like Fn keys, Ctrl, Shift, Esc etc.

Let me know what you think 😄 

### Issue
https://github.com/glortho/react-keydown/issues/56